### PR TITLE
Clone node-clinic-doctor-examples via https instead of SSH

### DIFF
--- a/content/documentation/doctor/02-getting-ready.md
+++ b/content/documentation/doctor/02-getting-ready.md
@@ -18,7 +18,7 @@ contains several for us to explore. Let's run the following to clone the reposit
 and install its dependencies:
 
 ```bash
-git clone git@github.com:nearform/node-clinic-doctor-examples.git
+git clone https://github.com/clinicjs/node-clinic-doctor-examples.git
 cd node-clinic-doctor-examples
 npm install
 ```

--- a/content/documentation/index.md
+++ b/content/documentation/index.md
@@ -73,7 +73,7 @@ Flags
 **4.** We have a set of example apps on Github. Let's run through the first one using [Clinic.js Doctor](/doctor/) and autocannon:
 
 ```bash
-git clone git@github.com:nearform/node-clinic-doctor-examples.git
+git clone https://github.com/clinicjs/node-clinic-doctor-examples.git
 cd node-clinic-doctor-examples
 npm install
 clinic doctor --autocannon [ / ] -- node ./slow-io


### PR DESCRIPTION
Hey everyone :D 
Since I don't have an SSH key configured, when I try to clone with the current command, I get in output: 

```bash
Cloning into 'node-clinic-doctor-examples'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

Using the `https://github.com/clinicjs/node-clinic-doctor-examples.git` is probably a better option (?). I've also noticed that in the other clone examples the doc is using https as well