### PR TITLE
Changed min Node version in docs

### DIFF
--- a/content/documentation/index.md
+++ b/content/documentation/index.md
@@ -9,7 +9,7 @@ metaData:
 
 Before you get started with Clinic.js, first let's make sure we install it on our machines and run a couple of tests just to make sure everything is working fine. Let's follow these steps to kick off:
 
-**1.** Note: You must use a version of Node.js `>= 8.11.1`
+**1.** Note: You must use a version of Node.js `>= 16`
 
 ```bash
 npm install -g clinic


### PR DESCRIPTION
In the [clinic README file](https://github.com/clinicjs/node-clinic) the min Node.js version is 16 (based on [this PR](https://github.com/clinicjs/node-clinic/pull/454)). I just aligned the right version in the website docs :) 